### PR TITLE
Fix install_requires typo in setup.py

### DIFF
--- a/setup_data.py
+++ b/setup_data.py
@@ -112,7 +112,7 @@ setup_dict = dict(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.5',
         ],
-    requires=[
+    install_requires=[
         'PyYAML',
         'cffi',
         'matplotlib',


### PR DESCRIPTION
Corrects a small typo which was preventing pip from install dependencies automatically.

I would recommend investigating using Tox to run your tests – it packages up your code and installs it into a virtualenv before running your unit tests. As a result it does a good job of catching packaging errors. This would also simplify your `.travis.yml` file.