### PR TITLE
Change name of high-level random voltage source???

### DIFF
--- a/PySpice/Spice/HighLevelElement.py
+++ b/PySpice/Spice/HighLevelElement.py
@@ -798,7 +798,7 @@ class AmplitudeModulatedCurrentSource(CurrentSource, AmplitudeModulatedMixin):
 
 ####################################################################################################
 
-class RandomVoltageVoltageSource(VoltageSource, RandomMixin):
+class RandomVoltageSource(VoltageSource, RandomMixin):
 
     r"""This class implements a random waveform voltage source.
 


### PR DESCRIPTION
RandomVoltageVoltageSource ===> RandomVoltageSource ???

Did you mean to include 'Voltage' twice in the class name?
