### PR TITLE
Logging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ spice-examples/xyce-test2.csv
 stargazers.txt
 user-tests/
 xyce.diff
+PySpice.egg-info/
+

--- a/PySpice/Logging/Logging.py
+++ b/PySpice/Logging/Logging.py
@@ -32,7 +32,9 @@ import PySpice.Config.ConfigInstall as ConfigInstall
 ####################################################################################################
 
 def setup_logging(application_name='PySpice',
-                  config_file=ConfigInstall.Logging.default_config_file):
+                  config_file=ConfigInstall.Logging.default_config_file
+                  loglevel=''):
+    #TODO: Add function/module docstring
 
     logging_config_file_name = ConfigInstall.Logging.find(config_file)
     logging_config = yaml.load(open(logging_config_file_name, 'r'))
@@ -54,5 +56,8 @@ def setup_logging(application_name='PySpice',
     if 'PySpiceLogLevel' in os.environ:
         numeric_level = getattr(logging, os.environ['PySpiceLogLevel'], None)
         logger.setLevel(numeric_level)
+    if loglevel:
+        level = logging.getLevelName(loglevel)
+        logger.setLevel(level)
 
     return logger

--- a/PySpice/Logging/Logging.py
+++ b/PySpice/Logging/Logging.py
@@ -32,7 +32,7 @@ import PySpice.Config.ConfigInstall as ConfigInstall
 ####################################################################################################
 
 def setup_logging(application_name='PySpice',
-                  config_file=ConfigInstall.Logging.default_config_file
+                  config_file=ConfigInstall.Logging.default_config_file,
                   loglevel=''):
     #TODO: Add function/module docstring
 


### PR DESCRIPTION
This pull request implements suggestions as in https://github.com/FabriceSalvaire/PySpice/issues/121 , which add  a new optional argument for `Logging.setup_logging()` which is `loglevel`, which sets the logging level for each script, which follows https://docs.python.org/3/library/logging.html#logging-levels

TODO:

- [ ] Add docstring so that there is documentation
- [ ] Add new loglevel `SPICEINFO` so that we can print useful information from Spice output without printing all those useless debug information
