### PR TITLE
Implement reading of times for PieceWiseLinearMixin, and fix netlist generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ install:
 
 script:
     - python unit-test/Spice/test_BasicElement.py
+    - python unit-test/Spice/test_HighLevelElement.py

--- a/PySpice/Spice/HighLevelElement.py
+++ b/PySpice/Spice/HighLevelElement.py
@@ -353,6 +353,11 @@ class PieceWiseLinearMixin(SourceMixinAbc):
     delay time time = td. The current source still needs to be patched, td and r are not yet
     available.
 
+    `values` should be given as a list of (`Time`, `Value`)-tuples, e.g.::
+
+        PieceWiseLinearVoltageSource(Circuit(''), 'inpwl1', '1', '0',
+            values=[(0, 0), (10@u_ms, 0), (11@u_ms, 5@u_V), (20@u_ms, 5@u_V)])
+
     """
 
     ##############################################

--- a/PySpice/Spice/HighLevelElement.py
+++ b/PySpice/Spice/HighLevelElement.py
@@ -361,7 +361,7 @@ class PieceWiseLinearMixin(SourceMixinAbc):
 
         # Fixme: default
 
-        self.values = [self.__as_unit__(x) for x in values]
+        self.values = sum(([as_s(t), self.__as_unit__(x)] for (t, x) in values), [])
         self.repeate_time = as_s(repeate_time)
         self.delay_time = as_s(delay_time)
 
@@ -371,7 +371,7 @@ class PieceWiseLinearMixin(SourceMixinAbc):
 
         # Fixme: to func?
         return ('PWL(' +
-                join_list(self.values) +
+                join_list(self.values) + ' ' +
                 join_dict({'r':self.repeate_time, 'td':self.delay_time}) + # OrderedDict(
                 ')')
 

--- a/PySpice/Tools/StringTools.py
+++ b/PySpice/Tools/StringTools.py
@@ -65,5 +65,5 @@ def join_list(items):
 
 def join_dict(d):
     return ' '.join(["{}={}".format(key, str_spice(value))
-                     for key, value in d.items()
+                     for key, value in sorted(d.items())
                      if value is not None])

--- a/setup_data.py
+++ b/setup_data.py
@@ -32,7 +32,7 @@ if pyspice_path.name == 'conf.py':
 else:
     pyspice_path = pyspice_path.parent
 init_path = pyspice_path.joinpath('PySpice', '__init__.py')
-with open(init_path) as fh:
+with open(str(init_path)) as fh:
     try:
         version = re.findall(r"^__version__ = '([^']+)'\r?$", fh.read(), re.M)[0]
     except IndexError:

--- a/unit-test/Spice/test_HighLevelElement.py
+++ b/unit-test/Spice/test_HighLevelElement.py
@@ -1,0 +1,53 @@
+####################################################################################################
+#
+# PySpice - A Spice Package for Python
+# Copyright (C) 2014 Fabrice Salvaire
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+####################################################################################################
+
+####################################################################################################
+
+import unittest
+
+####################################################################################################
+
+from PySpice.Spice.HighLevelElement import *
+from PySpice.Spice.Netlist import Circuit
+from PySpice.Unit import *
+
+####################################################################################################
+
+class TestHighLevelElement(unittest.TestCase):
+
+    ##############################################
+
+    def _test_spice_declaration(self, element, spice_declaration):
+
+        self.assertEqual(str(element), spice_declaration)
+
+    ##############################################
+
+    def test(self):
+
+        self._test_spice_declaration(PieceWiseLinearVoltageSource(Circuit(''), 'inpwl1', '1', '0',
+                                                                  values=[(0, 0), (10@u_ms, 0), (11@u_ms, 5@u_V), (20@u_ms, 5@u_V)]),
+                                     'Vinpwl1 1 0 PWL(0s 0V 10ms 0V 11ms 5V 20ms 5V r=0s td=0.0s)')
+
+####################################################################################################
+
+if __name__ == '__main__':
+
+    unittest.main()


### PR DESCRIPTION
Currently, PieceWiseLinearMixin does not read (time, value) pairs as documented, but expects a list of values of the target unit. The generated netlist does not contain times and is not valid SPICE syntax, as a space is missing.
This PR implements reading a list of (time, value)-tuples and adds a space in the output, so that the generated netlist syntax is acceptable by SPICE (tested with ngSpice 28 and 30).