### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ python:
     - 3.5
     - 3.6
     - 3.7
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 install:
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
     - 3.5
+    - 3.6
+    - 3.7
 
 install:
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
     - 3.5
     - 3.6
-    - 3.7
 matrix:
   include:
     - python: 3.7

--- a/PySpice/Tools/StringTools.py
+++ b/PySpice/Tools/StringTools.py
@@ -65,5 +65,5 @@ def join_list(items):
 
 def join_dict(d):
     return ' '.join(["{}={}".format(key, str_spice(value))
-                     for key, value in d.items()
+                     for key, value in sorted(d.items())
                      if value is not None])

--- a/setup_data.py
+++ b/setup_data.py
@@ -32,7 +32,7 @@ if pyspice_path.name == 'conf.py':
 else:
     pyspice_path = pyspice_path.parent
 init_path = pyspice_path.joinpath('PySpice', '__init__.py')
-with open(init_path) as fh:
+with open(str(init_path)) as fh:
     try:
         version = re.findall(r"^__version__ = '([^']+)'\r?$", fh.read(), re.M)[0]
     except IndexError:


### PR DESCRIPTION
A small incompatibility with Python 3.5 led to the Travis build failing. I also made StringTools.join_dict() sort the items lexicographically, so that a stable parameter order is guaranteed for (future) unit tests.
