### PR TITLE
Setting default yaml loader to prevent warning

### DIFF
--- a/PySpice/Logging/Logging.py
+++ b/PySpice/Logging/Logging.py
@@ -44,7 +44,7 @@ def setup_logging(application_name='PySpice',
     """
 
     logging_config_file_name = ConfigInstall.Logging.find(config_file)
-    logging_config = yaml.load(open(logging_config_file_name, 'r'))
+    logging_config = yaml.load(open(logging_config_file_name, 'r'), Loader=yaml.FullLoader)
 
     if ConfigInstall.OS.on_linux:
         # Fixme: \033 is not interpreted in YAML


### PR DESCRIPTION
Calling the yaml.load() function without a specified Loader=...is deprecated and results in a warning during runtime. The default loader used in this scenario is yaml.FullLaoader. Explicitly setting the argument wont change the function of the code, but there will be no warning shown.
