### PR TITLE
Preserve docstrings for element shortcut methods

### DIFF
--- a/PySpice/Spice/__init__.py
+++ b/PySpice/Spice/__init__.py
@@ -52,8 +52,10 @@ high_level_elements = _get_elements(HighLevelElement)
 for element_class in spice_elements + high_level_elements:
 
     def _make_function(element_class):
-        def function(self, *args, **kwargs):
-            return element_class(self, *args, **kwargs)
+        function = lambda self, *args, **kwargs: element_class(self, *args, **kwargs)
+
+        # Preserve docstrings for element shortcuts
+        function.__doc__ = element_class.__doc__
         return function
 
     func = _make_function(element_class)


### PR DESCRIPTION
Adding a small improvement to ensure docstrings are preserved when shortcut methods are added. This is mainly UX motivated as I'm a Jupyter and shift-tab addict.