### PR TITLE
parser: permit lines with leading whitespace

### DIFF
--- a/PySpice/Spice/Parser.py
+++ b/PySpice/Spice/Parser.py
@@ -817,6 +817,7 @@ class SpiceParser:
         lines = []
         current_line = None
         for line_index, line_string in enumerate(raw_lines):
+            line_string = line_string.lstrip(' ')
             if line_string.startswith('+'):
                 current_line.append(line_string[1:].strip('\r\n'))
             else:


### PR DESCRIPTION
This commit removes any leading whitespace from input source file lines when parsing. Ngspice handles this fine.

For example, if you use [this file](http://espice.ugr.es/espice/src/modelos_subckt/ti/lf411c.mod) with ngspice
```
$ ngspice
ngspice -> source lf411c.mod
```
it works, but pyspice complains about using ' ' as a prefix.