### PR TITLE
Fix check-install script for Windows

### DIFF
--- a/PySpice/Scripts/pyspice_post_installation.py
+++ b/PySpice/Scripts/pyspice_post_installation.py
@@ -122,7 +122,7 @@ class PySpicePostInstallation:
 
         if ConfigInstall.OS.on_windows:
             print('OS is Windows')
-            library = NGSPICE_PATH.LIBRARY_PATH
+            library = NgSpiceShared.LIBRARY_PATH
         elif ConfigInstall.OS.on_osx:
             print('OS is OSX')
             library = 'ngspice'


### PR DESCRIPTION
The `--check-install` script doesn't run on Windows due to a typo.  This PR fixes it.