### PR TITLE
test_Netlist: Disregard line endings in spice declaration comparisons

### DIFF
--- a/unit-test/Spice/test_Netlist.py
+++ b/unit-test/Spice/test_Netlist.py
@@ -56,8 +56,10 @@ class TestNetlist(unittest.TestCase):
     ##############################################
 
     def _test_spice_declaration(self, circuit, spice_declaration):
-
-        self.assertEqual(str(circuit), spice_declaration[1:])
+        # Ignore line endings and blank lines
+        circuit_lines = [*filter(None, str(circuit).splitlines(False))]
+        expected_lines = [*filter(None, spice_declaration.splitlines(False))]
+        self.assertEqual(circuit_lines, expected_lines)
 
     ##############################################
 


### PR DESCRIPTION
Some tests in `test_Netlist.py` don't pass on Windows due to discrepancies in the line endings.  This PR fixes them by discarding line endings when comparing spice declarations.