### PR TITLE
Fix Error in PySpice.Spice.Netlist._str_parameters

### DIFF
--- a/PySpice/Spice/Netlist.py
+++ b/PySpice/Spice/Netlist.py
@@ -1279,7 +1279,7 @@ class Circuit(Netlist):
 
     def _str_parameters(self):
         if self._parameters:
-            return join_lines(self._parameters, prefix='.param ') + os.linesep
+            return '.param ' + join_dict(self._parameters) + os.linesep
         else:
             return ''
 


### PR DESCRIPTION
The methods uses ```join_lines(self._parameters, prefix='.param ')```
but ```self._parameters``` is a ```dict```. This makes the method
```PySpice.Spice.Netlist.parameter('name','expression')``` to fail when used.

I fixed the code by calling the right function for dict object
(i.e. ```join_dict(self._parameters)``` )
and updated the string construction