### PR TITLE
Changes to make it easier to use PySpice with a large archive of SPICE models

### DIFF
--- a/PySpice/Spice/Parser.py
+++ b/PySpice/Spice/Parser.py
@@ -854,10 +854,19 @@ class SpiceParser:
         if self._title.startswith(title_statement):
             self._title = self._title[len(title_statement):]
 
+        # SUBCKT and MODEL files often start with their commands as the
+        # first line so they'll parse incorrectly if that line is removed.
+        # For everything else, assume the first line is a TITLE line and
+        # remove it.
+        if str(lines[0]).startswith(('.model', '.subckt')):
+            start_index = 0
+        else:
+            start_index = 1
+
         statements = []
         sub_circuit = None
         scope = statements
-        for line in lines[1:]:
+        for line in lines[start_index:]:
             # print('>', repr(line))
             text = str(line)
             lower_case_text = text.lower() # !
@@ -873,7 +882,7 @@ class SpiceParser:
                     sub_circuit = None
                     scope = statements
                 elif lower_case_text.startswith('title'):
-                    # override fist line
+                    # override first line
                     self._title = Title(line)
                     scope.append(self._title)
                 elif lower_case_text.startswith('end'):


### PR DESCRIPTION
I made some small changes to PySpice to make it easier to work with [this large archive of SPICE models](https://github.com/kicad-spice-library/KiCad-Spice-Library):

* `SpiceLibrary` will continue to traverse `root_path` and parse files even after the parser finds errors in a library file.
* `search()` method was added to `SpiceLibrary` to search and return a dict of all models/subcircuits having names that match a regular expression.
* `SpiceParser` now accepts files that have no title line and start immediately with `.model` or `.subckt` statements.

