### PR TITLE
Added spice library support

### DIFF
--- a/PySpice/Spice/Netlist.py
+++ b/PySpice/Spice/Netlist.py
@@ -1184,13 +1184,13 @@ class Circuit(Netlist):
         self._ground = ground
         self._global_nodes = set(global_nodes) # .global
         self._includes = [] # .include
+        self._libs = [] # .lib
         self._parameters = {} # .param
 
         # Fixme: not implemented
         #  .csparam
         #  .func
         #  .if
-        #  .lib
 
     ##############################################
 
@@ -1222,6 +1222,18 @@ class Circuit(Netlist):
 
     ##############################################
 
+    def lib(self, name, section=None):
+
+        """Load a library."""
+
+        v = (name, section)
+        if v not in self._libs:
+            self._libs.append(v)
+        else:
+            self._logger.warn(f"Duplicated lib {v}")
+
+    ##############################################
+
     def parameter(self, name, expression):
         """Set a parameter."""
         self._parameters[str(name)] = str(expression)
@@ -1237,6 +1249,7 @@ class Circuit(Netlist):
 
         netlist = self._str_title()
         netlist += self._str_includes(simulator)
+        netlist += self._str_libs(simulator)
         netlist += self._str_globals()
         netlist += self._str_parameters()
         netlist += super().__str__()
@@ -1263,6 +1276,27 @@ class Circuit(Netlist):
                 real_paths.append(path)
 
             return join_lines(real_paths, prefix='.include ') + os.linesep
+        else:
+            return ''
+
+    ##############################################
+
+    def _str_libs(self, simulator=None):
+
+        if self._libs:
+            libs = []
+            for lib, section in self._libs:
+                lib = Path(str(lib)).resolve()
+                if simulator:
+                    lib_flavour = Path(str(lib) + '@' + simulator)
+                    if lib_flavour.exists():
+                        lib = lib_flavour
+                s = ".lib {}".format(lib)
+                if section:
+                    s += " {}".format(section)
+                libs.append(s)
+
+            return os.linesep.join(libs) + os.linesep
         else:
             return ''
 


### PR DESCRIPTION
I am using ASIC Spice models from TSMC. They distribute the models of all the devices from their technology in one spice library file. They also use different sections to have models of the same device in different process corners. They use the following to define section in the spice file:
```
.LIB _sectionname_
...
.ENDL _sectionname_
```
In my case they provide five different models for the logic transistors in sections 'TT', 'FF', 'SS', 'SF', 'FS'; with the first letter the corner for the nmos and the second the corner for the pmos. They also have sections 'TT_3V', 'FF_3V', 'SS_3V', 'SF_3V', 'FS_3V' for the models of the IO transistors.
Usage of these files is not by including them but by using a `.LIB "filename" section` in your spice source file. In order to be able to do that I implemented support for this in this PR.

I am open for discussion on having support for this in the `SpiceLibrary`. One of the problems for generic support by `SpiceLibrary` is that TSMC and likely other foundries reuse the same model name for the device in different technologies (e.g 180nm, 65m, ...) so the logic device has the same name for different technologies so `SpiceLibrary` will have difficulty in making a distinction between models when different spice files are in the path it scans.