### PR TITLE
Performance optimization: dispatch multiple alter commands jointly

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -903,6 +903,7 @@ class NgSpiceShared:
     ##############################################
 
     def _alter(self, command, device, kwargs):
+        # Performance optimization: dispatch multiple alter commands jointly
         device_name = device.lower()
         commands = []
         commands_str_len = 0

--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -904,10 +904,22 @@ class NgSpiceShared:
 
     def _alter(self, command, device, kwargs):
         device_name = device.lower()
+        commands = []
+        commands_str_len = 0
         for key, value in kwargs.items():
             if isinstance(value, (list, tuple)):
                 value = '[ ' + ' '.join(value) + ' ]'
-            self.exec_command('{} {} {} = {}'.format(command, device_name, key, value))
+            cmd = '{} {} {} = {}'.format(command, device_name, key, value)
+            # performance optimization: collect multiple alter commands and 
+            #                           dispatch them jointly
+            commands.append(cmd)
+            commands_str_len += len(cmd)
+            if commands_str_len + len(commands) > self.__MAX_COMMAND_LENGTH__:
+                self.exec_command(';'.join(commands[:-1]))
+                commands = commands[-1:]
+                commands_str_len = len(commands[0])
+        if commands:
+            self.exec_command(';'.join(commands))
 
     ##############################################
 


### PR DESCRIPTION
This PR collects multiple `alter` commands until the maximum command length is reached, concatenates them into a single command string and dispatches them jointly.

In my particular application, this reduced run-time by a factor of almost 3.

If you are not too happy with this PR I won't feel offended. I have implemented this modification using subclassing for my particular application but thought I would share in case anybody has the same issue.