### PR TITLE
Bump ngspice version to 33

### DIFF
--- a/PySpice/Spice/NgSpice/SimulationType.py
+++ b/PySpice/Spice/NgSpice/SimulationType.py
@@ -81,7 +81,7 @@ SIMULATION_TYPE[27] = (
     'charge',
 )
 
-LAST_VERSION = 32 # released on May 4th, 2020
+LAST_VERSION = 33 # released on October 18th, 2020
 
 for version in range(28, LAST_VERSION +1):
     SIMULATION_TYPE[version] = SIMULATION_TYPE[27]


### PR DESCRIPTION
ngspice-33 released on 18 October 2020: http://ngspice.sourceforge.net/news.html
