### PR TITLE
Assign units on creation of temperature-sweep vectors

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -101,7 +101,7 @@ from PySpice.Probe.WaveForm import (
     WaveForm,
 )
 from PySpice.Tools.EnumFactory import EnumFactory
-from PySpice.Unit import u_V, u_A, u_s, u_Hz, u_F
+from PySpice.Unit import u_V, u_A, u_s, u_Hz, u_F, u_Degree
 
 from .SimulationType import SIMULATION_TYPE
 
@@ -597,6 +597,7 @@ class NgSpiceShared:
             self._simulation_type.current: u_A,
             self._simulation_type.frequency: u_Hz,
             self._simulation_type.capacitance: u_F,
+            self._simulation_type.temperature: u_Degree,
         }
 
         # Prevent paging output of commands (hangs)


### PR DESCRIPTION
Currently, if one runs `.dc TEMP -50 150 1` and reads the results, PySpice complains with `Unit is None for temp-sweep temperature`. This PR fixes this by assigning a unit for temperature sweep vectors as is already done for other vector types.