### PR TITLE
Fix ngspice download URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ examples/c-examples/ngspice_cb/ng_shared_test_sl/ng_shared_test_sl.depend
 examples/c-examples/ngspice_cb/ng_shared_test_sl/ng_shared_test_sl.layout
 examples/c-examples/ngspice_cb/ng_shared_test_sl_v/
 examples/c-examples/ngspice_cb/ng_shared_test_v/
+
+Spice64_dll/

--- a/PySpice/Scripts/pyspice_post_installation.py
+++ b/PySpice/Scripts/pyspice_post_installation.py
@@ -228,17 +228,18 @@ class PySpicePostInstallation:
         # src = dll_path.joinpath('ngspice-{}.dll'.format(self.ngspice_version))
         src = 'ngspice-{}.dll'.format(self.ngspice_version)
         target = dll_path.joinpath('ngspice.dll')
-        if target.exists():
-            target.unlink()
-        try:
-            target.symlink_to(src)
-        except OSError:
-            # OSError: symbolic link privilege not held
-            # Windows: If User Account Control (UAC) is on, any user with the "Create Symbolic
-            #   Links" privilege that is not in the Administrators group can simply create a
-            #   symbolic link.  For users within the Administrators group and with UAC on, the user
-            #   must "Run as Administrator".
-            shutil.copy(target.parent.joinpath(src), target)
+        if dll_path.joinpath(src).exists():
+            if target.exists():
+                target.unlink()
+            try:
+                target.symlink_to(src)
+            except OSError:
+                # OSError: symbolic link privilege not held
+                # Windows: If User Account Control (UAC) is on, any user with the "Create Symbolic
+                #   Links" privilege that is not in the Administrators group can simply create a
+                #   symbolic link.  For users within the Administrators group and with UAC on, the user
+                #   must "Run as Administrator".
+                shutil.copy(target.parent.joinpath(src), target)
 
         spinit_path = spice64_path.joinpath('share', 'ngspice', 'scripts', 'spinit')
         with open(spinit_path) as fh:

--- a/PySpice/Scripts/pyspice_post_installation.py
+++ b/PySpice/Scripts/pyspice_post_installation.py
@@ -228,6 +228,7 @@ class PySpicePostInstallation:
         # src = dll_path.joinpath('ngspice-{}.dll'.format(self.ngspice_version))
         src = 'ngspice-{}.dll'.format(self.ngspice_version)
         target = dll_path.joinpath('ngspice.dll')
+        # For ngspice version <=31 DLL naming did not contain a version number
         if dll_path.joinpath(src).exists():
             if target.exists():
                 target.unlink()

--- a/PySpice/Scripts/pyspice_post_installation.py
+++ b/PySpice/Scripts/pyspice_post_installation.py
@@ -111,6 +111,7 @@ class PySpicePostInstallation:
     NGSPICE_WINDOWS_DLL_URL = NGSPICE_RELEASE_URL + '/{0}/ngspice-{0}_dll_64.zip'
     NGSPICE_WINDOWS_DLL_OLD_URL = NGSPICE_RELEASE_URL + '/old-releases/{0}/ngspice-{0}_dll_64.zip'
     NGSPICE_MANUAL_URL = NGSPICE_RELEASE_URL + '/{0}/ngspice-{0}-manual.pdf/download'
+    NGSPICE_MANUAL_OLD_URL = NGSPICE_RELEASE_URL + '/old-releases/{0}/ngspice-{0}-manual.pdf/download'
 
     ##############################################
 
@@ -258,7 +259,12 @@ class PySpicePostInstallation:
 
     def download_ngspice_manual(self):
         url = self.NGSPICE_MANUAL_URL.format(self.ngspice_version)
-        self._download_file(url, 'ngspice-manual-{}.pdf'.format(self.ngspice_version))
+        try:
+            self._download_file(url, 'ngspice-manual-{}.pdf'.format(self.ngspice_version))
+        except requests.exceptions.HTTPError:
+            print('Download failed, trying another URL...')
+            url = self.NGSPICE_MANUAL_OLD_URL.format(self.ngspice_version)
+            self._download_file(url, 'ngspice-manual-{}.pdf'.format(self.ngspice_version))
 
     ##############################################
 

--- a/PySpice/Scripts/pyspice_post_installation.py
+++ b/PySpice/Scripts/pyspice_post_installation.py
@@ -177,7 +177,7 @@ class PySpicePostInstallation:
 
     ##############################################
 
-    def _donwload_file(self, url, dst_path):
+    def _download_file(self, url, dst_path):
         print('Get {} ... -> {}'.format(url, dst_path))
         response = requests.get(url, allow_redirects=True)
         assert(response.status_code == requests.codes.ok)
@@ -210,7 +210,7 @@ class PySpicePostInstallation:
             url = self.NGSPICE_WINDOWS_DLL_URL.format(self.ngspice_version)
             zip_path = tmp_directory.joinpath('ngspice-{}_dll_64.zip'.format(self.ngspice_version))
             dst_path = Path(NgSpice.__file__).parent
-            self._donwload_file(url, zip_path)
+            self._download_file(url, zip_path)
             with ZipFile(zip_path) as zip_file:
                 zip_file.extractall(path=dst_path)
                 print('Extracted {} in {}'.format(zip_path, dst_path.joinpath('Spice64_dll')))
@@ -251,7 +251,7 @@ class PySpicePostInstallation:
 
     def download_ngspice_manual(self):
         url = self.NGSPICE_MANUAL_URL.format(self.ngspice_version)
-        self._donwload_file(url, 'ngspice-manual-{}.pdf'.format(self.ngspice_version))
+        self._download_file(url, 'ngspice-manual-{}.pdf'.format(self.ngspice_version))
 
     ##############################################
 
@@ -438,7 +438,7 @@ class PySpicePostInstallation:
             return
 
         with tempfile.TemporaryDirectory() as tmp_directory:
-            self._donwload_file(RELEASE_URL, zip_path)
+            self._download_file(RELEASE_URL, zip_path)
             with ZipFile(zip_path) as zip_file:
                 zip_file.extractall(path=tmp_directory)
             examples_path = Path(tmp_directory).joinpath('PySpice-{}'.format(version), 'examples')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib>=3.2
 numpy>=1.18
 ply>=3.11
 scipy>=1.4
+requests


### PR DESCRIPTION
ngspice directory structure changed from

https://sourceforge.net/projects/ngspice/files/ng-spice-rework/32/ngspice-32_dll_64.zip

to

https://sourceforge.net/projects/ngspice/files/ng-spice-rework/old-releases/32/ngspice-32_dll_64.zip

Try old-releases folder if main folder fails for a given version.

Raise a visible exception if 404 or other HTTP error to help identify
future problems.